### PR TITLE
Feature/27

### DIFF
--- a/apps/fe/src/app/posts/[id]/page.tsx
+++ b/apps/fe/src/app/posts/[id]/page.tsx
@@ -2,13 +2,17 @@
 
 import { Avatar, Box, HStack, Text } from "@chakra-ui/react";
 import { useParams } from "next/navigation";
+import { useSelector } from "react-redux";
 import { defaultImgUrl, posts } from "@/app/posts/const";
+import type { RootState } from "@/store/store";
 
 export default function PostDetail() {
   const params = useParams();
   const id: string = params.id ? String(params.id) : "";
 
-  const post = posts.find((e) => e.id === id);
+  const postState = useSelector((state: RootState) => state.post);
+  const allPosts = [...postState.posts, ...posts];
+  const post = allPosts.find((e) => e.id === id);
 
   if (!post) return <div>Not Found</div>;
   return (

--- a/apps/fe/src/app/posts/page.tsx
+++ b/apps/fe/src/app/posts/page.tsx
@@ -1,13 +1,18 @@
 "use client";
 
 import { Center } from "@chakra-ui/react";
+import { useSelector } from "react-redux";
 import Posts from "@/components/posts/Posts";
+import type { RootState } from "@/store/store";
 import { posts } from "./const";
 
 export default function PostsView() {
+  const postState = useSelector((state: RootState) => state.post);
+  const allPosts = [...postState.posts, ...posts];
+
   return (
     <Center minH="100vh">
-      <Posts posts={posts} />
+      <Posts posts={allPosts} />
     </Center>
   );
 }

--- a/apps/fe/src/store/features/post/postSlice.ts
+++ b/apps/fe/src/store/features/post/postSlice.ts
@@ -26,7 +26,7 @@ export const postSlice = createSlice({
         post: action.payload.post,
         createdAt: new Date().toISOString(),
       };
-      state.posts.push(newPost);
+      state.posts.unshift(newPost); // 先頭に入れる
     },
     deletePost: (state, action: PayloadAction<string>) => {
       state.posts = state.posts.filter(


### PR DESCRIPTION
## 関連するIssue
#27

## 変更内容
* `/posts/create`ページで投稿した内容を`/posts`ページで閲覧可能
* `/posts`ページで記事をクリックし、`/posts/[id]`ページで詳細を閲覧可能
* Redux内で保存される投稿の配列に記事を入れる際に、先頭から入れるように変更

## 動作確認
* `/register`ページでアカウント登録、`/posts/create`ページで投稿、`/posts`ページで閲覧・記事をクリック、`/posts/[id]`ページで記事の詳細を閲覧