### PR TITLE
[fix] 記事閲覧ページから記事詳細ページへの遷移がSPAになっていない箇所を修正

### DIFF
--- a/apps/fe/src/components/posts/Post.tsx
+++ b/apps/fe/src/components/posts/Post.tsx
@@ -1,4 +1,5 @@
 import { Avatar, Box, HStack, Link, Text } from "@chakra-ui/react";
+import NextLink from "next/link";
 
 type PostProps = {
   postId: string;
@@ -16,7 +17,7 @@ export default function Post({
   img,
 }: PostProps) {
   return (
-    <Link href={`/posts/${postId}`}>
+    <Link href={`/posts/${postId}`} as={NextLink}>
       <Box
         borderWidth="1px"
         borderColor="black"


### PR DESCRIPTION
## 変更内容
* Linkコンポーネントに`as={NextLink}`を付与してSPAになるように修正

## 動作確認
* 記事閲覧ページの記事をクリックし、記事詳細ページへの遷移で再読込していないか？