### PR TITLE
postしたらpostsページに遷移する

### DIFF
--- a/apps/fe/src/app/posts/create/PostForm.tsx
+++ b/apps/fe/src/app/posts/create/PostForm.tsx
@@ -1,3 +1,4 @@
+"use client";
 import {
   Button,
   Center,
@@ -17,6 +18,7 @@ import { POST_MAX_LENGTH } from "@/app/posts/const";
 import { addPost } from "@/store/features/post/postSlice";
 import type { RootState } from "@/store/store";
 import { type PostFormInput, schema } from "./schema";
+import { useRouter } from "next/navigation";
 
 export default function PostForm() {
   const dispatch = useDispatch();
@@ -34,6 +36,7 @@ export default function PostForm() {
 
   const contentValue = watch("content") || "";
   const isOverLimit = contentValue.length > POST_MAX_LENGTH;
+  const router = useRouter();
 
   const onError = useCallback(
     (err: unknown) => console.log("Validation Errors:", err),
@@ -42,8 +45,9 @@ export default function PostForm() {
   const onSubmit = useCallback(
     (data: PostFormInput) => {
       dispatch(addPost({ name: accountState.username, post: data.content }));
+      router.push("/posts");
     },
-    [dispatch, accountState.username],
+    [dispatch, accountState.username, router],
   );
 
   useEffect(() => {

--- a/apps/fe/src/app/posts/create/PostForm.tsx
+++ b/apps/fe/src/app/posts/create/PostForm.tsx
@@ -10,6 +10,7 @@ import {
   VStack,
 } from "@chakra-ui/react";
 import { yupResolver } from "@hookform/resolvers/yup";
+import { useRouter } from "next/navigation";
 import { useCallback, useEffect } from "react";
 import { useForm } from "react-hook-form";
 import { FaUser } from "react-icons/fa";
@@ -18,7 +19,6 @@ import { POST_MAX_LENGTH } from "@/app/posts/const";
 import { addPost } from "@/store/features/post/postSlice";
 import type { RootState } from "@/store/store";
 import { type PostFormInput, schema } from "./schema";
-import { useRouter } from "next/navigation";
 
 export default function PostForm() {
   const dispatch = useDispatch();


### PR DESCRIPTION
## 関連するIssue

<!-- 関連するIssue番号を記載してください (例: #123) -->
- 34
## 変更内容
このプルリクエストは、apps/fe プロジェクトの PostForm コンポーネントを更新し、フォーム送信後のナビゲーション機能を強化するものです。最も重要な変更点として、クライアントディレクティブの追加、Next.jsの useRouter フックの統合、そして投稿作成成功時にユーザーをリダイレクトするためのフォーム送信ロジックの更新が含まれます。

ナビゲーションの強化：

コンポーネントがクライアントサイドのコンテキストで動作することを保証するため、PostForm.tsx ファイルの先頭に "use client"; ディレクティブを追加しました。

プログラムによるナビゲーションを可能にするため、next/navigation から useRouter フックをインポートしました。

PostForm コンポーネント内で useRouter を使用して router インスタンスを宣言しました。

フォーム送信が成功した後、ユーザーを投稿ページにリダイレクトするために、onSubmit コールバックに router.push("/posts") の呼び出しを含むように更新しました。それに応じて useCallback フックの依存配列を調整しました。

## 動作確認
- postしたらpostsページに遷移すること
- postが成功したかみていながい問題ない？？
<!-- 変更内容が正しく動作することを確認した方法を記載してください -->
<!-- (例)
- [ ] `npm run build` が成功すること
- [ ] `npm run dev` で起動した開発環境で、〇〇画面の表示が崩れていないこと
-->

