### PR TITLE
[fix] トップページにアクセスした際、Headerが描画される問題の修正

### DIFF
--- a/apps/fe/src/components/layout/layoutConfig.ts
+++ b/apps/fe/src/components/layout/layoutConfig.ts
@@ -4,6 +4,10 @@ export type LayoutConfig = {
 };
 
 export const layoutConfig: Record<string, LayoutConfig> = {
+  "/": {
+    showHeader: false,
+    showSidebar: false,
+  },
   "/register": {
     showHeader: false,
     showSidebar: false,


### PR DESCRIPTION
## 関連するIssue
#43

## 変更内容
* `http://localhost:3000`にアクセスした際、Headerを描画しているが、`headerPathList`に`/`に対応する設定がないため、エラーとなるので、`/`へのアクセス時はHeader自体を描画しないようにlayoutConfigに設定を追加しました。

## 動作確認
* `/`にアクセスし、エラーが出ないことを確認