### PR TITLE
Feature/40 ユーザーは安全にログアウトできる

### DIFF
--- a/apps/fe/src/app/layout.tsx
+++ b/apps/fe/src/app/layout.tsx
@@ -1,9 +1,9 @@
 import type { Metadata } from "next";
 import "./globals.css";
+import AuthGuard from "@/components/auth/AuthGuard";
 import ConfigBasedLayout from "@/components/layout/ConfigBasedLayout";
 import { GlobalThemeProvider } from "@/components/ui/GlobalThemeProvider";
 import { ReduxProvider } from "@/store/provider";
-import AuthGuard from "@/components/auth/AuthGuard";
 
 export const metadata: Metadata = {
   title: "oz-chat",

--- a/apps/fe/src/app/layout.tsx
+++ b/apps/fe/src/app/layout.tsx
@@ -3,6 +3,7 @@ import "./globals.css";
 import ConfigBasedLayout from "@/components/layout/ConfigBasedLayout";
 import { GlobalThemeProvider } from "@/components/ui/GlobalThemeProvider";
 import { ReduxProvider } from "@/store/provider";
+import AuthGuard from "@/components/auth/AuthGuard";
 
 export const metadata: Metadata = {
   title: "oz-chat",
@@ -19,7 +20,9 @@ export default function RootLayout({
       <body>
         <GlobalThemeProvider>
           <ReduxProvider>
-            <ConfigBasedLayout>{children}</ConfigBasedLayout>
+            <AuthGuard>
+              <ConfigBasedLayout>{children}</ConfigBasedLayout>
+            </AuthGuard>
           </ReduxProvider>
         </GlobalThemeProvider>
       </body>

--- a/apps/fe/src/components/auth/AuthConfig.ts
+++ b/apps/fe/src/components/auth/AuthConfig.ts
@@ -1,0 +1,2 @@
+// 認証が不要な公開パス
+export const PUBLIC_PATHS = ['/login', '/register'];

--- a/apps/fe/src/components/auth/AuthConfig.ts
+++ b/apps/fe/src/components/auth/AuthConfig.ts
@@ -1,2 +1,2 @@
 // 認証が不要な公開パス
-export const PUBLIC_PATHS = ['/login', '/register'];
+export const PUBLIC_PATHS = ["/login", "/register"];

--- a/apps/fe/src/components/auth/AuthGuard.tsx
+++ b/apps/fe/src/components/auth/AuthGuard.tsx
@@ -1,29 +1,32 @@
-'use client';
+"use client";
 
-import { useEffect } from 'react';
-import { usePathname, useRouter } from 'next/navigation';
-import { useSelector } from 'react-redux';
-import type { RootState } from '@/store/store';
+import { usePathname, useRouter } from "next/navigation";
+import { useEffect, useState } from "react";
+import { useSelector } from "react-redux";
+import type { RootState } from "@/store/store";
 import { PUBLIC_PATHS } from "./AuthConfig";
 
 export default function AuthGuard({ children }: { children: React.ReactNode }) {
   const router = useRouter();
   const pathname = usePathname();
-  const currentAccount = useSelector((state: RootState) => state.currentAccount);
+  const currentAccount = useSelector(
+    (state: RootState) => state.currentAccount,
+  );
+  const [isAuthChecked, setIsAuthChecked] = useState(false);
 
   useEffect(() => {
-    // currentAccount.username が存在しない場合、未認証とみなす
     const isAuthenticated = !!currentAccount.username;
-
-    // 現在のパスが公開パスかどうかをチェック
     const isPublicPage = PUBLIC_PATHS.includes(pathname);
 
-    // 未認証かつ公開ページでない場合、ログインページにリダイレクト
     if (!isAuthenticated && !isPublicPage) {
-      router.push('/login');
+      router.push("/login");
+    } else {
+      setIsAuthChecked(true);
     }
   }, [currentAccount, pathname, router]);
 
-  // 認証済み、または公開ページの場合は子コンポーネントをそのまま表示
-  return <>{children}</>;
+  // 認証チェックが完了しており、認証済みか公開ページの場合のみ子要素を表示
+  if (isAuthChecked) {
+    return <>{children}</>;
+  }
 }

--- a/apps/fe/src/components/auth/AuthGuard.tsx
+++ b/apps/fe/src/components/auth/AuthGuard.tsx
@@ -1,0 +1,29 @@
+'use client';
+
+import { useEffect } from 'react';
+import { usePathname, useRouter } from 'next/navigation';
+import { useSelector } from 'react-redux';
+import type { RootState } from '@/store/store';
+import { PUBLIC_PATHS } from "./AuthConfig";
+
+export default function AuthGuard({ children }: { children: React.ReactNode }) {
+  const router = useRouter();
+  const pathname = usePathname();
+  const currentAccount = useSelector((state: RootState) => state.currentAccount);
+
+  useEffect(() => {
+    // currentAccount.username が存在しない場合、未認証とみなす
+    const isAuthenticated = !!currentAccount.username;
+
+    // 現在のパスが公開パスかどうかをチェック
+    const isPublicPage = PUBLIC_PATHS.includes(pathname);
+
+    // 未認証かつ公開ページでない場合、ログインページにリダイレクト
+    if (!isAuthenticated && !isPublicPage) {
+      router.push('/login');
+    }
+  }, [currentAccount, pathname, router]);
+
+  // 認証済み、または公開ページの場合は子コンポーネントをそのまま表示
+  return <>{children}</>;
+}

--- a/apps/fe/src/components/sidebar/SideBar.tsx
+++ b/apps/fe/src/components/sidebar/SideBar.tsx
@@ -15,7 +15,7 @@ export default function SideBar() {
     >
       <VStack as="nav" align="stretch" pt={8}>
         {sideBarNavItems.map((item) => (
-          <SideBarContent {...item} key={item.href} />
+          <SideBarContent {...item} key={item.label} />
         ))}
       </VStack>
     </Box>

--- a/apps/fe/src/components/sidebar/SideBarContent.tsx
+++ b/apps/fe/src/components/sidebar/SideBarContent.tsx
@@ -7,6 +7,7 @@ export default function SideBarContent({
   label,
   icon: IconComponent,
   onClick,
+  color,
 }: SideBarNavItem) {
   const router = useRouter();
   const dispatch = useDispatch();
@@ -24,6 +25,7 @@ export default function SideBarContent({
       }}
       w="100%"
       justifyContent="flex-start"
+      color={color}
     >
       <Box mr={2}>
         <IconComponent />

--- a/apps/fe/src/components/sidebar/SideBarContent.tsx
+++ b/apps/fe/src/components/sidebar/SideBarContent.tsx
@@ -1,16 +1,20 @@
-import { Box, Link } from "@chakra-ui/react";
-import NextLink from "next/link";
+import { Box, Button } from "@chakra-ui/react";
+import { useRouter } from "next/navigation";
+import { useDispatch } from "react-redux";
 import type { SideBarNavItem } from "./sideBarNavItems";
 
 export default function SideBarContent({
-  href,
   label,
   icon: IconComponent,
+  onClick,
 }: SideBarNavItem) {
+  const router = useRouter();
+  const dispatch = useDispatch();
+
   return (
-    <Link
-      as={NextLink}
-      href={href}
+    <Button
+      variant="ghost"
+      onClick={() => onClick(router, dispatch)}
       display="flex"
       p={2}
       borderRadius="md"
@@ -18,11 +22,13 @@ export default function SideBarContent({
         bg: "fontColor.main",
         color: "background.default",
       }}
+      w="100%"
+      justifyContent="flex-start"
     >
       <Box mr={2}>
         <IconComponent />
       </Box>
       {label}
-    </Link>
+    </Button>
   );
 }

--- a/apps/fe/src/components/sidebar/sideBarNavItems.ts
+++ b/apps/fe/src/components/sidebar/sideBarNavItems.ts
@@ -1,16 +1,39 @@
+import type { Dispatch } from "@reduxjs/toolkit";
+import type { AppRouterInstance } from "next/dist/shared/lib/app-router-context.shared-runtime";
 import type { IconType } from "react-icons";
-import { FaHome, FaPencilAlt, FaUser } from "react-icons/fa";
+import { FaHome, FaPencilAlt, FaSignOutAlt, FaUser } from "react-icons/fa";
+import { clearCurrentAccountInfo } from "@/store/features/account/currentAccountSlice";
 
 export type SideBarNavItem = {
-  href: string;
   label: string;
   icon: IconType;
+  onClick: (router: AppRouterInstance, dispatch: Dispatch) => void;
 };
 
 const sideBarNavItems: SideBarNavItem[] = [
-  { href: "/posts", label: "ホーム", icon: FaHome },
-  { href: "/profile", label: "プロフィール", icon: FaUser },
-  { href: "/posts/create", label: "記事投稿", icon: FaPencilAlt },
+  {
+    label: "ホーム",
+    icon: FaHome,
+    onClick: (router) => router.push("/posts"),
+  },
+  {
+    label: "プロフィール",
+    icon: FaUser,
+    onClick: (router) => router.push("/profile"),
+  },
+  {
+    label: "記事投稿",
+    icon: FaPencilAlt,
+    onClick: (router) => router.push("/posts/create"),
+  },
+  {
+    label: "ログアウト",
+    icon: FaSignOutAlt,
+    onClick: (router, dispatch) => {
+      dispatch(clearCurrentAccountInfo());
+      router.push("/login");
+    },
+  },
 ];
 
 export default sideBarNavItems;

--- a/apps/fe/src/components/sidebar/sideBarNavItems.ts
+++ b/apps/fe/src/components/sidebar/sideBarNavItems.ts
@@ -8,6 +8,7 @@ export type SideBarNavItem = {
   label: string;
   icon: IconType;
   onClick: (router: AppRouterInstance, dispatch: Dispatch) => void;
+  color?: string;
 };
 
 const sideBarNavItems: SideBarNavItem[] = [
@@ -33,6 +34,7 @@ const sideBarNavItems: SideBarNavItem[] = [
       dispatch(clearCurrentAccountInfo());
       router.push("/login");
     },
+    color: "red.500",
   },
 ];
 


### PR DESCRIPTION
## 関連するIssue
#40

## 変更内容
* SideBarにログアウト項目を追加。
* ログアウトのみ赤色のフォントカラーに設定。
* ChakraUIのLinkコンポーネントから、AppRouter.pushを用いるルーティングに変更
* 認証ガードを付与し、未認証ユーザーが`/register`と`/login`以外のページに直接アクセスした際に、`/login`ページが表示されるように変更

## 動作確認
* 未認証で認証が必要なページに直接アクセス
* 認証済みで認証が必要なページに直接アクセス
* ログアウトでログインページに飛ぶか？

## UI
<img width="940" height="337" alt="Screenshot 2025-07-31 13 17 36" src="https://github.com/user-attachments/assets/d9cb8de1-9808-4a83-891f-51ab33b366a0" />
