### PR TITLE
string型からDate型に変更

### DIFF
--- a/apps/fe/src/components/posts/Post.tsx
+++ b/apps/fe/src/components/posts/Post.tsx
@@ -6,7 +6,7 @@ type PostProps = {
   postId: string;
   name: string;
   post: string;
-  createdAt: string;
+  createdAt: Date;
   img: string;
 };
 

--- a/apps/fe/src/components/posts/Posts.tsx
+++ b/apps/fe/src/components/posts/Posts.tsx
@@ -2,20 +2,21 @@
 
 import { List } from "@chakra-ui/react";
 import { defaultImgUrl } from "@/app/posts/const";
-import Post from "./Post";
-import type { Post as TypePost } from "./type";
+import PostComponent from "./Post";
+import type { Post } from "./type";
 
 type PostsProps = {
-  posts: TypePost[];
+  posts: Post[];
 };
 
 export default function Posts({ posts }: PostsProps) {
+  console.log(posts);
   return (
     <List.Root listStyle="none" width="100%">
       {posts.map((e) => {
         return (
           <List.Item key={e.id}>
-            <Post
+            <PostComponent
               postId={e.id}
               name={e.name}
               post={e.post}

--- a/apps/fe/src/components/posts/type.ts
+++ b/apps/fe/src/components/posts/type.ts
@@ -2,5 +2,5 @@ export type Post = {
   id: string;
   name: string;
   post: string;
-  createdAt: string;
+  createdAt: Date;
 };

--- a/apps/fe/src/store/features/post/postSlice.ts
+++ b/apps/fe/src/store/features/post/postSlice.ts
@@ -12,7 +12,7 @@ export const postSlice = createSlice({
         id: crypto.randomUUID(), // Use UUID for unique ID
         name: action.payload.name,
         post: action.payload.post,
-        createdAt: new Date().toISOString(),
+        createdAt: new Date(),
       };
       state.unshift(newPost); // 先頭に入れる
     },

--- a/apps/fe/src/store/store.ts
+++ b/apps/fe/src/store/store.ts
@@ -6,10 +6,55 @@ import storage from "redux-persist/lib/storage";
 import accountsReducer from "./features/account/accountsSlice";
 import currentAccountReducer from "./features/account/currentAccountSlice";
 import postReducer from "./features/post/postSlice";
+import { Post } from "@/components/posts/type";
+
+// Dateオブジェクトの変換処理
+const dateTransform = {
+  // localStorageに保存する際にDateを文字列に変換
+  in: (state: any) => {
+    if (!state) return state;
+    
+    // postスライスのcreatedAtを文字列に変換
+    if (state.post && Array.isArray(state.post)) {
+      return {
+        ...state,
+        post: state.post.map((post: Post) => ({
+          ...post,
+          createdAt: post.createdAt instanceof Date 
+            ? post.createdAt.toISOString() 
+            : post.createdAt
+        }))
+      };
+    }
+    
+    return state;
+  },
+  
+  // localStorageから読み込む際に文字列をDateに変換
+  out: (state: any) => {
+    if (!state) return state;
+    
+    // postスライスのcreatedAtをDateに変換
+    if (state.post && Array.isArray(state.post)) {
+      return {
+        ...state,
+        post: state.post.map((post: Post) => ({
+          ...post,
+          createdAt: typeof post.createdAt === 'string' 
+            ? new Date(post.createdAt) 
+            : post.createdAt
+        }))
+      };
+    }
+    
+    return state;
+  }
+};
 
 const persistConfig = {
   key: "root",
   storage, // storageに永続化
+  transforms: [dateTransform], // 変換処理を追加
 };
 
 const rootReducer = combineReducers({

--- a/apps/fe/src/store/store.ts
+++ b/apps/fe/src/store/store.ts
@@ -28,6 +28,10 @@ export const store = configureStore({
       serializableCheck: {
         // Ignore these action types
         ignoredActions: ["persist/PERSIST"],
+        // Ignore these field paths in all actions
+        ignoredActionPaths: ["payload.createdAt"],
+        // Ignore these paths in the state
+        ignoredPaths: ["post"],
       },
     }),
 });

--- a/apps/fe/src/utils/date.test.ts
+++ b/apps/fe/src/utils/date.test.ts
@@ -13,63 +13,63 @@ describe("formatRelativeTime", () => {
   test('5秒以内は"今"を返す', () => {
     const mockDate = new Date("2024-01-01T12:00:03.000Z");
     vi.setSystemTime(mockDate);
-    const result = formatRelativeTime("2024-01-01T12:00:00.000Z");
+    const result = formatRelativeTime(new Date("2024-01-01T12:00:00.000Z"));
     expect(result).toBe("今");
   });
 
   test('1分以内は"X秒前"を返す', () => {
     const mockDate = new Date("2024-01-01T12:00:30.000Z");
     vi.setSystemTime(mockDate);
-    const result = formatRelativeTime("2024-01-01T12:00:00.000Z");
+    const result = formatRelativeTime(new Date("2024-01-01T12:00:00.000Z"));
     expect(result).toBe("30秒前");
   });
 
   test('1時間以内は"X分前"を返す', () => {
     const mockDate = new Date("2024-01-01T12:30:00.000Z");
     vi.setSystemTime(mockDate);
-    const result = formatRelativeTime("2024-01-01T12:00:00.000Z");
+    const result = formatRelativeTime(new Date("2024-01-01T12:00:00.000Z"));
     expect(result).toBe("30分前");
   });
 
   test('1日以内は"X時間前"を返す', () => {
     const mockDate = new Date("2024-01-01T18:00:00.000Z");
     vi.setSystemTime(mockDate);
-    const result = formatRelativeTime("2024-01-01T12:00:00.000Z");
+    const result = formatRelativeTime(new Date("2024-01-01T12:00:00.000Z"));
     expect(result).toBe("6時間前");
   });
 
   test('1日以上は"YYYY年MM月DD日"を返す', () => {
     const mockDate = new Date("2024-01-03T12:00:00.000Z");
     vi.setSystemTime(mockDate);
-    const result = formatRelativeTime("2024-01-01T12:00:00.000Z");
+    const result = formatRelativeTime(new Date("2024-01-01T12:00:00.000Z"));
     expect(result).toBe("2024年1月1日");
   });
 
   test("異なる年の日付", () => {
     const mockDate = new Date("2024-01-01T12:00:00.000Z");
     vi.setSystemTime(mockDate);
-    const result = formatRelativeTime("2023-12-31T12:00:00.000Z");
+    const result = formatRelativeTime(new Date("2023-12-31T12:00:00.000Z"));
     expect(result).toBe("2023年12月31日");
   });
 
   test("境界値テスト（59秒）", () => {
     const mockDate = new Date("2024-01-01T12:00:59.000Z");
     vi.setSystemTime(mockDate);
-    const result = formatRelativeTime("2024-01-01T12:00:00.000Z");
+    const result = formatRelativeTime(new Date("2024-01-01T12:00:00.000Z"));
     expect(result).toBe("59秒前");
   });
 
   test("境界値テスト（59分）", () => {
     const mockDate = new Date("2024-01-01T12:59:00.000Z");
     vi.setSystemTime(mockDate);
-    const result = formatRelativeTime("2024-01-01T12:00:00.000Z");
+    const result = formatRelativeTime(new Date("2024-01-01T12:00:00.000Z"));
     expect(result).toBe("59分前");
   });
 
   test("境界値テスト（23時間）", () => {
     const mockDate = new Date("2024-01-02T11:00:00.000Z");
     vi.setSystemTime(mockDate);
-    const result = formatRelativeTime("2024-01-01T12:00:00.000Z");
+    const result = formatRelativeTime(new Date("2024-01-01T12:00:00.000Z"));
     expect(result).toBe("23時間前");
   });
 });

--- a/apps/fe/src/utils/date.ts
+++ b/apps/fe/src/utils/date.ts
@@ -1,6 +1,6 @@
-export function formatRelativeTime(dateString: string): string {
+export function formatRelativeTime(date: Date): string {
   const now = new Date();
-  const targetDate = new Date(dateString);
+  const targetDate = date;
   const diffInSeconds = Math.floor(
     (now.getTime() - targetDate.getTime()) / 1000,
   );


### PR DESCRIPTION
## 関連するIssue
<!-- 関連するIssue番号を記載してください (例: - #123) -->
- #57

## 変更内容
<!-- このPRで行った変更内容を簡潔に説明してください -->
このプルリクエストは、コードベース全体で `createdAt` フィールドを `string` 型から `Date` 型に移行し、一貫性を確保し、型の安全性を向上させることに焦点を当てています。主な変更点には、型定義、Reduxの状態管理、永続化ロジック、および関連するユーティリティ関数の更新が含まれます。

### 型の更新：
* `apps/fe/src/components/posts/Post.tsx` の `PostProps` と `apps/fe/src/components/posts/type.ts` の `Post` 型を更新し、`createdAt` フィールドに `string` の代わりに `Date` を使用するようにしました。(diffhunk://#diff-735ba43043925cd6ea92a14115423179fff7888086abebf54352d64059fbef14L9-R9)(diffhunk://#diff-c5f482e91f7ed3c1fd185cfde543904a1c83383bb94123f8866334f1f847167fL5-R5)

### Reduxの状態管理：
* `apps/fe/src/store/features/post/postSlice.ts` の `postSlice` を変更し、`createdAt` をISO文字列ではなく `Date` オブジェクトとして保存するようにしました。
* Reduxの永続化のために `Date` オブジェクトのシリアライズとデシリアライズを処理するため、`apps/fe/src/store/store.ts` に `dateTransform` を追加しました。
* シリアライズ可能なチェック中に `createdAt` を無視するようにReduxの設定を更新しました。

### ユーティリティ関数の調整：
* `apps/fe/src/utils/date.ts` の `formatRelativeTime` をリファクタリングし、以前の `string` 入力を置き換えて `Date` オブジェクトを直接受け入れるようにしました。
* `apps/fe/src/utils/date.test.ts` の対応するテストケースを更新し、検証に `Date` オブジェクトを使用するようにしました。

### コンポーネントとインポートの調整：
* 明確さと一貫性のために `apps/fe/src/components/posts/Posts.tsx` で `Post` コンポーネントのインポートを調整し、`Post` を `PostComponent` に名前変更しました。`posts` のデバッグログを追加しました。