### PR TITLE
55/Update SideBarとコンテンツの横幅を少し増やす etc

### DIFF
--- a/apps/fe/src/app/profile/components/UserInfo.tsx
+++ b/apps/fe/src/app/profile/components/UserInfo.tsx
@@ -14,7 +14,9 @@ export default function UserInfo() {
   return (
     <Box
       w="size.full"
-      p="6"
+      py="5"
+      pl="3"
+      pr="4"
       backgroundColor="background.default"
       borderWidth="1px"
       borderColor="border"
@@ -45,10 +47,10 @@ export default function UserInfo() {
               </Text>
             </Button>
           </HStack>
-          <Text mb="3" wordBreak="break-word">
+          <Text mb="2" wordBreak="break-word">
             {currentAccount.message}
           </Text>
-          <HStack mb="4">
+          <HStack mb="2">
             <Text fontSize="s" color="gray.500" mr="2">
               <Text as="span" fontSize="m" fontWeight="bold" pr="1">
                 {follow}

--- a/apps/fe/src/components/posts/Post.tsx
+++ b/apps/fe/src/components/posts/Post.tsx
@@ -31,14 +31,16 @@ export default function Post({
       <Box
         borderWidth="1px"
         borderColor="border"
-        py="4"
-        px="5"
+        pt="4"
+        pb="5"
+        pl="4"
+        pr="5"
         width="100%"
         bg="background.default"
         _hover={{ bg: "background.hover" }}
       >
         <HStack align="top">
-          <Avatar.Root colorPalette="gray">
+          <Avatar.Root colorPalette="gray" mr="1">
             <Avatar.Fallback name="O Z" />
             <Avatar.Image src={img} />
           </Avatar.Root>

--- a/apps/fe/src/components/ui/theme.ts
+++ b/apps/fe/src/components/ui/theme.ts
@@ -24,11 +24,11 @@ const config = defineConfig({
         // INFO ChakraUIはデフォルトで0~96などのパラメータを用意済み
         sideBar: {
           height: { value: "100vh" },
-          width: { value: "15vw" },
+          width: { value: "14vw" },
         },
         mainContent: {
           height: { value: "100vh" },
-          width: { value: "30vw" },
+          width: { value: "32vw" },
         },
         full: { value: "100%" }, // レイアウト全体を広げる
         min: { value: "min-content" }, // 最小幅に合わせる


### PR DESCRIPTION
## 関連するIssue
#55

## 変更内容
- サイドバーの幅
- mainContentの幅
- UserInfoのpadding
- Postのpadding

## 動作確認
``/posts`` ``/profile`` へアクセス

## UI
<img width="3779" height="1853" alt="Screenshot from 2025-08-01 21-01-09" src="https://github.com/user-attachments/assets/bbc84b85-ffb9-48d8-9398-02917ba3a7f9" />
