### PR TITLE
53/Fix NotFoundの際、HeaderとSidebarを非表示に

### DIFF
--- a/apps/fe/src/components/layout/layoutConfig.ts
+++ b/apps/fe/src/components/layout/layoutConfig.ts
@@ -1,28 +1,45 @@
 export type LayoutConfig = {
+  match: (pathname: string) => boolean;
   showHeader: boolean;
   showSidebar: boolean;
 };
 
-export const layoutConfig: Record<string, LayoutConfig> = {
-  "/": {
-    showHeader: false,
-    showSidebar: false,
-  },
-  "/register": {
-    showHeader: false,
-    showSidebar: false,
-  },
-  "/login": {
-    showHeader: false,
-    showSidebar: false,
-  },
-  // デフォルト設定
-  default: {
+export const showLayoutConfigs: LayoutConfig[] = [
+  {
+    match: (pathname) => pathname === "/posts",
     showHeader: true,
     showSidebar: true,
   },
-};
+  {
+    match: (pathname) => pathname === "/profile",
+    showHeader: true,
+    showSidebar: true,
+  },
+  {
+    match: (pathname) => pathname === "/posts/create",
+    showHeader: true,
+    showSidebar: true,
+  },
+  {
+    match: (pathname) => pathname === "/search",
+    showHeader: true,
+    showSidebar: true,
+  },
+  {
+    match: (pathname) => /^\/posts\/[^/]+$/.test(pathname),
+    showHeader: true,
+    showSidebar: true,
+  },
+];
 
 export function getLayoutConfig(pathname: string): LayoutConfig {
-  return layoutConfig[pathname] || layoutConfig.default;
+  const found = showLayoutConfigs.find((config) => config.match(pathname));
+  if (!found) {
+    return {
+      match: () => false,
+      showHeader: false,
+      showSidebar: false,
+    };
+  }
+  return found;
 }


### PR DESCRIPTION
## 関連するIssue
#53

## 変更内容
- NotFoundの際、HeaderとSidebarを非表示になるよう、判定ロジックを修正しました

## 動作確認
``/pos`` ``/a`` etc

## その他
``/posts/{存在しないid}``のケースだけ、対応できません
``/posts/eb13f0a2-f20d-4721-b779-60b4c6f60803``はあるけど、``/posts/N0t-F0un6``は存在しないみたいなのは、matchでは不可能でした。

## UI
<img width="925" height="2012" alt="Screenshot from 2025-08-01 21-13-04" src="https://github.com/user-attachments/assets/0c2e286d-ff6d-40ca-9e59-e0f4c263cd3e" />